### PR TITLE
Middleware message handling refactoring

### DIFF
--- a/backend/jupyter-middleware/dharpa/vre/context/context.py
+++ b/backend/jupyter-middleware/dharpa/vre/context/context.py
@@ -1,35 +1,119 @@
 from abc import ABC, abstractmethod
-from typing import Dict, Optional
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Dict, List, Optional
+
+from dharpa.vre.types import Workflow
+from dharpa.vre.types.generated import DataTabularDataFilter
 from tinypubsub.simple import SimplePublisher
 
-from dharpa.vre.types import Workflow, WorkflowStructure
+if TYPE_CHECKING:
+    from pyarrow import Table
+
+
+@dataclass
+class UpdatedIO:
+    step_id: str
+    io_ids: List[str]
 
 
 class AppContext(ABC):
-    @abstractmethod
-    def load_workflow(self, workflow: Workflow) -> None:
-        ...
+    '''
+    Application context interface that needs to be implemented for
+    a particular backend. There are likely only two backends:
+    "kiara" and "mock".
+    '''
 
-    @property
+    _event_workflow_structure_updated = SimplePublisher[Workflow]()
+    _event_step_input_values_updated = SimplePublisher[UpdatedIO]()
+
     @abstractmethod
-    def workflow_structure_updated(self) -> SimplePublisher[WorkflowStructure]:
+    def load_workflow(self, workflow_file: Path) -> None:
+        '''
+        Load workflow and set it as the current workflow.
+        A synchronous method which should raise an exception if
+        something goes wrong. When the method returns - the workflow
+        is ready to use.
+        '''
         ...
 
     @property
     @abstractmethod
     def current_workflow(self) -> Optional[Workflow]:
+        '''
+        Returns current workflow or `None` if no workflow has been loaded.
+        '''
+        ...
+
+    @property
+    def workflow_structure_updated(self) -> SimplePublisher[Workflow]:
+        '''
+        Event fired whenever current workflow structure is updated.
+        This happens either when the user changes the structure or when
+        the workflow is loaded.
+        '''
+        return self._event_workflow_structure_updated
+
+    @abstractmethod
+    def get_step_input_values(
+        self,
+        step_id: str,
+        input_ids: Optional[List[str]] = None
+    ) -> Optional[Dict]:
+        '''
+        Return input values for a step. Optionally return values
+        only for requested input ids.
+
+        NOTE: There are 2 types of inputs: simple (scalar) and tabular.
+        This method handles only simple types. If an input id of a
+        tabluar input is requested in `input_ids`, it is simply ignored.
+        '''
         ...
 
     @abstractmethod
-    def get_current_workflow_step_input_values(
-        self,
-        step_id: str
-    ) -> Optional[Dict]:
-        ...
-
-    def update_current_workflow_step_input_values(
+    def update_step_input_values(
         self,
         step_id: str,
         input_values: Optional[Dict]
     ) -> Optional[Dict]:
+        '''
+        Update input values for a step. The values dict may not contain
+        all the values to be updated.
+
+        NOTE: There are 2 types of inputs: simple (scalar) and tabular.
+        This method handles only simple types. If an input id of a
+        tabluar input is provided in `input_values`, it is simply ignored.
+        '''
+        ...
+
+    @property
+    def step_input_values_updated(self) -> SimplePublisher[UpdatedIO]:
+        '''
+        Event fired when input values have been updated.
+        That concerns both simple and tabular types.
+        The payload contains only input ids without values.
+        '''
+        return self._event_step_input_values_updated
+
+    @abstractmethod
+    def get_step_tabular_input_value(
+        self,
+        step_id: str,
+        input_id: str,
+        filter: Optional[DataTabularDataFilter] = None
+    ) -> Optional['Table']:
+        '''
+        Return value of a tabular input of a step.
+        The `filter` argument defines the batch of the input to get.
+        The last requested filter value should be stored within
+        the context and used to return the same batch if filter is
+        not provided.
+        '''
+        ...
+
+    @abstractmethod
+    def is_tabular_input(self, step_id: str, input_id: str) -> bool:
+        '''
+        Returns `True` if input type is tabular. `False` otherwise.
+        '''
         ...

--- a/backend/jupyter-middleware/dharpa/vre/context/context.py
+++ b/backend/jupyter-middleware/dharpa/vre/context/context.py
@@ -117,3 +117,14 @@ class AppContext(ABC):
         Returns `True` if input type is tabular. `False` otherwise.
         '''
         ...
+
+    @abstractmethod
+    def get_step_tabular_input_filter(
+        self,
+        step_id: str,
+        input_id: str
+    ) -> DataTabularDataFilter:
+        '''
+        Return current value of the tabular filter for the step input.
+        '''
+        ...

--- a/backend/jupyter-middleware/dharpa/vre/context/context.py
+++ b/backend/jupyter-middleware/dharpa/vre/context/context.py
@@ -58,15 +58,17 @@ class AppContext(ABC):
     def get_step_input_values(
         self,
         step_id: str,
-        input_ids: Optional[List[str]] = None
+        input_ids: Optional[List[str]] = None,
+        include_tabular: Optional[bool] = None
     ) -> Optional[Dict]:
         '''
         Return input values for a step. Optionally return values
         only for requested input ids.
 
         NOTE: There are 2 types of inputs: simple (scalar) and tabular.
-        This method handles only simple types. If an input id of a
-        tabluar input is requested in `input_ids`, it is simply ignored.
+        By default this method handles only simple types. If an input id of a
+        tabluar input is requested in `input_ids`, and `include_tabular`
+        is not set to `True`, it is simply ignored.
         '''
         ...
 
@@ -126,5 +128,12 @@ class AppContext(ABC):
     ) -> DataTabularDataFilter:
         '''
         Return current value of the tabular filter for the step input.
+        '''
+        ...
+
+    @abstractmethod
+    def run_processing(self, step_id: Optional[str] = None):
+        '''
+        Run processing of data through the whole workflow.
         '''
         ...

--- a/backend/jupyter-middleware/dharpa/vre/context/mock/app_context.py
+++ b/backend/jupyter-middleware/dharpa/vre/context/mock/app_context.py
@@ -1,45 +1,56 @@
 import importlib.resources as pkg_resources
-from typing import Dict, Optional, Callable
-from dharpa.vre.utils.dataclasses import from_yaml
-from tinypubsub.simple import SimplePublisher
+from collections import defaultdict
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 
 from dharpa.vre.context.context import AppContext
-from dharpa.vre.types import Workflow, WorkflowStructure
 from dharpa.vre.context.mock import resources
+from dharpa.vre.types import Workflow, WorkflowStructure
+from dharpa.vre.types.generated import DataTabularDataFilter
+from dharpa.vre.utils.dataclasses import from_yaml
+
+if TYPE_CHECKING:
+    from pyarrow import Table
 
 WorkflowStructureUpdated = Callable[[WorkflowStructure], None]
+
+DEFAULT_TABULAR_FILTER = DataTabularDataFilter(
+    offset=0,
+    page_size=5
+)
 
 
 class MockAppContext(AppContext):
     _current_workflow: Optional[Workflow] = None
-    _steps_input_values: Dict[str, Optional[Dict]] = {}
-    _steps_output_values: Dict[str, Optional[Dict]] = {}
 
-    _event_workflow_structure_updated = SimplePublisher[WorkflowStructure]()
+    # steps i/o values: step_id -> { io_id -> value (if exists) }
+    _steps_input_values: Dict[str, Dict[str, Any]] = defaultdict(dict)
+    _steps_output_values: Dict[str, Dict[str, Any]] = defaultdict(dict)
+
+    # tabular i/o filters: step_id -> { io_id -> filter (if exists) }
+    _steps_inputs_tabular_filters: Dict[
+        str, Dict[str, DataTabularDataFilter]
+    ] = defaultdict(dict)
 
     def __init__(self):
-        workflow_file_content = pkg_resources.open_text(
-            resources, 'sample_workflow_1.yml')
-        workflow = from_yaml(Workflow, workflow_file_content)
-        self.load_workflow(workflow)
+        with pkg_resources.path(resources, 'sample_workflow_1.yml') as path:
+            self.load_workflow(path)
 
-    def load_workflow(self, workflow: Workflow) -> None:
-        # TODO: resolve modules from every step of the workflow
-        self._current_workflow = workflow
-        self._event_workflow_structure_updated.publish(
-            self._current_workflow.structure)
+    def load_workflow(self, workflow_file: Path) -> None:
+        with open(workflow_file, 'r') as f:
+            workflow = from_yaml(Workflow, f.read())
+            self._current_workflow = workflow
+        self.workflow_structure_updated.publish(
+            self._current_workflow)
 
     @property
     def current_workflow(self):
         return self._current_workflow
 
-    @property
-    def workflow_structure_updated(self):
-        return self._event_workflow_structure_updated
-
-    def get_current_workflow_step_input_values(
+    def get_step_input_values(
         self,
-        step_id: str
+        step_id: str,
+        input_ids: Optional[List[str]] = None
     ) -> Optional[Dict]:
         values = self._steps_input_values[step_id] \
             if step_id in self._steps_input_values else None
@@ -57,11 +68,44 @@ class MockAppContext(AppContext):
             self._steps_input_values[step_id] = values
         return values
 
-    def update_current_workflow_step_input_values(
+    def update_step_input_values(
         self,
         step_id: str,
         input_values: Optional[Dict]
     ) -> Optional[Dict]:
-        self._steps_input_values[step_id] = input_values
-        # TODO: processing here ?
+        self._steps_input_values[step_id] = input_values or {}
         return input_values
+
+    def get_step_tabular_input_value(
+        self,
+        step_id: str,
+        input_id: str,
+        filter: Optional[DataTabularDataFilter] = None
+    ) -> Optional['Table']:
+        if self._current_workflow is None:
+            return None
+
+        if input_id not in self._steps_input_values[step_id]:
+            return None
+
+        table: 'Table' = self._steps_input_values[step_id][input_id]
+
+        if filter is None:
+            filter = self._steps_inputs_tabular_filters[step_id].get(
+                input_id, DEFAULT_TABULAR_FILTER)
+
+        return table.slice(filter.offset, filter.page_size)
+
+    def is_tabular_input(self, step_id: str, input_id: str) -> bool:
+        if self._current_workflow is None:
+            return False
+
+        step = next((
+            x
+            for x in self._current_workflow.structure.steps
+            if x.id == step_id
+        ), None)
+
+        if input_id in step.inputs:
+            return step.inputs[input_id].is_tabular or False
+        return True

--- a/backend/jupyter-middleware/dharpa/vre/context/mock/app_context.py
+++ b/backend/jupyter-middleware/dharpa/vre/context/mock/app_context.py
@@ -93,6 +93,8 @@ class MockAppContext(AppContext):
         if filter is None:
             filter = self._steps_inputs_tabular_filters[step_id].get(
                 input_id, DEFAULT_TABULAR_FILTER)
+        else:
+            self._steps_inputs_tabular_filters[step_id][input_id] = filter
 
         return table.slice(filter.offset, filter.page_size)
 
@@ -109,3 +111,13 @@ class MockAppContext(AppContext):
         if input_id in step.inputs:
             return step.inputs[input_id].is_tabular or False
         return True
+
+    def get_step_tabular_input_filter(
+        self,
+        step_id: str,
+        input_id: str
+    ) -> DataTabularDataFilter:
+        return self._steps_inputs_tabular_filters[step_id].get(
+            input_id,
+            DEFAULT_TABULAR_FILTER
+        )

--- a/backend/jupyter-middleware/dharpa/vre/context/mock/app_context.py
+++ b/backend/jupyter-middleware/dharpa/vre/context/mock/app_context.py
@@ -1,3 +1,4 @@
+import dataclasses
 import importlib.resources as pkg_resources
 from collections import defaultdict
 from pathlib import Path
@@ -6,8 +7,10 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
 from dharpa.vre.context.context import AppContext
 from dharpa.vre.context.mock import resources
 from dharpa.vre.types import Workflow, WorkflowStructure
-from dharpa.vre.types.generated import DataTabularDataFilter
+from dharpa.vre.types.generated import DataTabularDataFilter, WorkflowStep
 from dharpa.vre.utils.dataclasses import from_yaml
+from dharpa.vre.modules import get_module_processor
+from stringcase import snakecase
 
 if TYPE_CHECKING:
     from pyarrow import Table
@@ -47,33 +50,90 @@ class MockAppContext(AppContext):
     def current_workflow(self):
         return self._current_workflow
 
+    def _get_step(self, step_id: str) -> Optional[WorkflowStep]:
+        return next((
+            x
+            for x in self._current_workflow.structure.steps
+            if x.id == step_id
+        ), None)
+
+    def _process_step(self, step_id: str) -> None:
+        step = self._get_step(step_id)
+        if step is None:
+            return
+
+        fn = get_module_processor(step.module_id)
+        if fn is not None:
+            inputs = self.get_step_input_values(step_id)
+            if inputs is not None:
+                inputs_keys = list(step.inputs.keys())
+                inputs_cls = dataclasses.make_dataclass(
+                    'Inputs', inputs_keys)
+                inputs = inputs_cls(**{k: inputs.get(k, None)
+                                       for k in inputs_keys})
+
+            outputs = self._get_step_output_values(step_id)
+            if outputs is not None:
+                outputs_keys = list(step.outputs.keys())
+                outputs_cls = dataclasses.make_dataclass(
+                    'Outputs', outputs_keys)
+                outputs = outputs_cls(
+                    **{k: outputs.get(k, None) for k in outputs_keys})
+
+            if inputs is not None and outputs is not None:
+                fn(inputs, outputs)
+
+                items = dataclasses.asdict(outputs).items()
+                for output_id, output_value in items:
+                    io = step.outputs.get(output_id)
+                    if io is not None and io.connection is not None:
+                        conn_step_id = io.connection.step_id
+                        conn_input_id = snakecase(io.connection.io_id)
+                        self._steps_input_values[
+                            conn_step_id][conn_input_id] = output_value
+                    else:
+                        self._steps_output_values[step_id][output_id] = \
+                            output_value
+
+    def _process_all_steps(self) -> None:
+        for s in self._current_workflow.structure.steps:
+            self._process_step(s.id)
+
     def get_step_input_values(
         self,
         step_id: str,
         input_ids: Optional[List[str]] = None
     ) -> Optional[Dict]:
-        values = self._steps_input_values[step_id] \
-            if step_id in self._steps_input_values else None
-        if values is None and self._current_workflow is not None:
-            step = next((
-                x
-                for x in self._current_workflow.structure.steps
-                if x.id == step_id
-            ), None)
-            values = {
-                input_id: state.default_value for input_id,
-                state in step.inputs.items()
-                if state.default_value is not None
-            }
-            self._steps_input_values[step_id] = values
-        return values
+        step = self._get_step(step_id)
+        if step is None:
+            return None
+
+        def get_value(input_id):
+            if input_id in self._steps_input_values[step_id]:
+                return self._steps_input_values[step_id][input_id]
+            else:
+                i = step.inputs.get(input_id, None)
+                # if i is not None and i.connection is not None:
+                if i is not None and i.default_value is not None:
+                    return i.default_value
+            return None
+
+        returned_inputs_ids = input_ids or list(step.inputs.keys())
+        values = {
+            i: get_value(i)
+            for i in returned_inputs_ids
+        }
+
+        return {k: v for k, v in values.items() if v is not None}
 
     def update_step_input_values(
         self,
         step_id: str,
         input_values: Optional[Dict]
     ) -> Optional[Dict]:
-        self._steps_input_values[step_id] = input_values or {}
+        for k, v in (input_values or {}).items():
+            self._steps_input_values[step_id][k] = v
+        self._process_all_steps()
         return input_values
 
     def get_step_tabular_input_value(
@@ -102,11 +162,7 @@ class MockAppContext(AppContext):
         if self._current_workflow is None:
             return False
 
-        step = next((
-            x
-            for x in self._current_workflow.structure.steps
-            if x.id == step_id
-        ), None)
+        step = self._get_step(step_id)
 
         if input_id in step.inputs:
             return step.inputs[input_id].is_tabular or False
@@ -121,3 +177,36 @@ class MockAppContext(AppContext):
             input_id,
             DEFAULT_TABULAR_FILTER
         )
+
+    def _get_step_output_values(
+        self,
+        step_id: str,
+        output_ids: Optional[List[str]] = None
+    ) -> Optional[Dict]:
+        step = self._get_step(step_id)
+        if step is None:
+            return None
+
+        def get_value(output_id):
+            if output_id in self._steps_output_values[step_id]:
+                return self._steps_output_values[step_id][output_id]
+            else:
+                io = step.outputs.get(output_id)
+                if io is not None and io.connection is not None:
+                    connection_step_id = io.connection.step_id
+                    connection_input_id = snakecase(io.connection.io_id)
+                    v = self._steps_input_values[connection_step_id].get(
+                        connection_input_id, None)
+                    if v is not None:
+                        return v
+                elif io is not None and io.default_value is not None:
+                    return io.default_value
+            return None
+
+        returned_outputs_ids = output_ids or list(step.outputs.keys())
+        values = {
+            i: get_value(i)
+            for i in returned_outputs_ids
+        }
+
+        return {k: v for k, v in values.items() if v is not None}

--- a/backend/jupyter-middleware/dharpa/vre/context/mock/resources/sample_workflow_1.yml
+++ b/backend/jupyter-middleware/dharpa/vre/context/mock/resources/sample_workflow_1.yml
@@ -10,11 +10,19 @@ structure:
       outputs:
         repositoryItems:
           isTabular: true
+          connection:
+            stepId: m0.5
+            ioId: repositoryItems
     - id: m0.5
       moduleId: dataSelection
       inputs:
         repositoryItems:
           isTabular: true
+          connection:
+            stepId: m0
+            ioId: repositoryItems
+        selectedItemsUris:
+          default: []
       outputs:
         selectedItems:
           isTabular: true
@@ -41,6 +49,7 @@ structure:
             ioId: c
         b:
           defaultValue: 5
+        operator: {}
       outputs:
         c: {}
     - id: m3

--- a/backend/jupyter-middleware/dharpa/vre/context/mock/resources/sample_workflow_1.yml
+++ b/backend/jupyter-middleware/dharpa/vre/context/mock/resources/sample_workflow_1.yml
@@ -51,7 +51,10 @@ structure:
           defaultValue: 5
         operator: {}
       outputs:
-        c: {}
+        c:
+          connection:
+            stepId: m3
+            ioId: y
     - id: m3
       moduleId: simplePlot
       inputs:

--- a/backend/jupyter-middleware/dharpa/vre/context/mock/resources/sample_workflow_1.yml
+++ b/backend/jupyter-middleware/dharpa/vre/context/mock/resources/sample_workflow_1.yml
@@ -8,7 +8,16 @@ structure:
         filenames: {}
         metadataSets: {}
       outputs:
-        repositoryItems: {}
+        repositoryItems:
+          isTabular: true
+    - id: m0.5
+      moduleId: dataSelection
+      inputs:
+        repositoryItems:
+          isTabular: true
+      outputs:
+        selectedItems:
+          isTabular: true
     - id: m1
       moduleId: twoArgsMathFunction
       inputs:

--- a/backend/jupyter-middleware/dharpa/vre/jupyter/base.py
+++ b/backend/jupyter-middleware/dharpa/vre/jupyter/base.py
@@ -61,6 +61,11 @@ class MessageHandler(ABC):
         self._publisher = publisher
         self._target = target
 
+        self.initialize()
+
+    def initialize(self):
+        pass
+
     @property
     def publisher(self):
         return self._publisher

--- a/backend/jupyter-middleware/dharpa/vre/jupyter/context.py
+++ b/backend/jupyter-middleware/dharpa/vre/jupyter/context.py
@@ -52,9 +52,10 @@ class Context(TargetPublisher):
         self._context = MockAppContext()
 
         self._handlers = {
-            Target.Workflow: WorkflowMessageHandler(self._context, self),
+            Target.Workflow: WorkflowMessageHandler(
+                self._context, self, Target.Workflow),
             Target.ModuleIO: ModuleIOHandler(
-                self._context, self)
+                self._context, self, Target.ModuleIO)
         }
 
         def _open_handle_factory(target: Target):

--- a/backend/jupyter-middleware/dharpa/vre/jupyter/context.py
+++ b/backend/jupyter-middleware/dharpa/vre/jupyter/context.py
@@ -91,7 +91,7 @@ class Context(TargetPublisher):
     def is_ready(self):
         return self._is_ready
 
-    def publish(self, target: Target, msg: MessageEnvelope) -> None:
+    def publish_on_target(self, target: Target, msg: MessageEnvelope) -> None:
         comm = self._comms[target]
         logger.debug(
             f'Message published on "{target}": {json.dumps(to_dict(msg))}')
@@ -125,14 +125,8 @@ class Context(TargetPublisher):
                 handler for target "{target}" and message
                 {json.dumps(message_data)}'''
             )
-            self.publish(
-                Target.Activity,
-                MessageEnvelope(
-                    action='error',
-                    content=to_dict(MsgError(
-                        id=error_id,
-                        message=f'Error occured while executing a message \
+            self.publish(MsgError(
+                id=error_id,
+                message=f'Error occured while executing a message \
                         handler for target "{target}": {str(e)}'
-                    ))
-                )
-            )
+            ))

--- a/backend/jupyter-middleware/dharpa/vre/jupyter/controller.py
+++ b/backend/jupyter-middleware/dharpa/vre/jupyter/controller.py
@@ -27,7 +27,7 @@ logger.setLevel(logging.DEBUG)
 logger.addHandler(logging.StreamHandler(sys.stdout))
 
 
-class Context(TargetPublisher):
+class IpythonKernelController(TargetPublisher):
     __instance = None
 
     _comms: Dict[Target, Comm] = {}
@@ -40,12 +40,12 @@ class Context(TargetPublisher):
 
     @staticmethod
     def start():
-        if Context.get_instance() is None:
-            Context()
+        if IpythonKernelController.get_instance() is None:
+            IpythonKernelController()
 
     @staticmethod
     def get_instance():
-        return Context.__instance
+        return IpythonKernelController.__instance
 
     def __init__(self):
         super().__init__()
@@ -86,7 +86,7 @@ class Context(TargetPublisher):
         )
 
         self._is_ready = True
-        Context.__instance = self
+        IpythonKernelController.__instance = self
 
     @property
     def is_ready(self):

--- a/backend/jupyter-middleware/dharpa/vre/jupyter/message_handlers/module_io.py
+++ b/backend/jupyter-middleware/dharpa/vre/jupyter/message_handlers/module_io.py
@@ -2,8 +2,11 @@ import logging
 
 from dharpa.vre.jupyter.base import MessageHandler
 from dharpa.vre.types.generated import (MsgModuleIOGetInputValues,
+                                        MsgModuleIOGetTabularInputValue,
                                         MsgModuleIOInputValuesUpdated,
+                                        MsgModuleIOTabularInputValueUpdated,
                                         MsgModuleIOUpdateInputValues)
+from dharpa.vre.utils.codec import serialize_table
 
 logger = logging.getLogger(__name__)
 
@@ -32,3 +35,19 @@ class ModuleIOHandler(MessageHandler):
             msg.id,
             values
         ))
+
+    def _handle_GetTabularInputValue(self,
+                                     msg: MsgModuleIOGetTabularInputValue):
+        value = self.context.get_step_tabular_input_value(
+            msg.id, msg.input_id, msg.filter)
+
+        current_filter = self.context.get_step_tabular_input_filter(
+            msg.id, msg.input_id)
+
+        if value is not None:
+            self.publisher.publish(MsgModuleIOTabularInputValueUpdated(
+                id=msg.id,
+                input_id=msg.input_id,
+                filter=current_filter,
+                value=serialize_table(value)
+            ))

--- a/backend/jupyter-middleware/dharpa/vre/jupyter/message_handlers/module_io.py
+++ b/backend/jupyter-middleware/dharpa/vre/jupyter/message_handlers/module_io.py
@@ -1,39 +1,34 @@
 import logging
 
-from dharpa.vre.jupyter.base import MessageEnvelope, MessageHandler
-from dharpa.vre.types.generated import (
-    MsgModuleIOGetInputValues,
-    MsgModuleIOInputValuesUpdated,
-    MsgModuleIOUpdateInputValues,
-)
-from dharpa.vre.utils.dataclasses import from_dict
+from dharpa.vre.jupyter.base import MessageHandler
+from dharpa.vre.types.generated import (MsgModuleIOGetInputValues,
+                                        MsgModuleIOInputValuesUpdated,
+                                        MsgModuleIOUpdateInputValues)
 
 logger = logging.getLogger(__name__)
 
 
 class ModuleIOHandler(MessageHandler):
 
-    def _handle_GetInputValues(self, msg: MessageEnvelope):
+    def _handle_GetInputValues(self, msg: MsgModuleIOGetInputValues):
         '''
         Return workflow step input values.
         '''
-        message = from_dict(MsgModuleIOGetInputValues, msg.content)
         values = self.context.get_current_workflow_step_input_values(
-            message.id)
+            msg.id)
 
         self.publisher.publish(MsgModuleIOInputValuesUpdated(
-            message.id,
+            msg.id,
             values
         ))
 
-    def _handle_UpdateInputValues(self, msg: MessageEnvelope):
-        message = from_dict(MsgModuleIOUpdateInputValues, msg.content)
+    def _handle_UpdateInputValues(self, msg: MsgModuleIOUpdateInputValues):
         values = self.context.update_current_workflow_step_input_values(
-            message.id,
-            message.input_values
+            msg.id,
+            msg.input_values
         )
 
         self.publisher.publish(MsgModuleIOInputValuesUpdated(
-            message.id,
+            msg.id,
             values
         ))

--- a/backend/jupyter-middleware/dharpa/vre/jupyter/message_handlers/module_io.py
+++ b/backend/jupyter-middleware/dharpa/vre/jupyter/message_handlers/module_io.py
@@ -1,6 +1,6 @@
 import logging
-from dharpa.vre.context.context import UpdatedIO
 
+from dharpa.vre.context.context import UpdatedIO
 from dharpa.vre.jupyter.base import MessageHandler
 from dharpa.vre.types.generated import (MsgModuleIOGetInputValues,
                                         MsgModuleIOGetTabularInputValue,
@@ -8,7 +8,7 @@ from dharpa.vre.types.generated import (MsgModuleIOGetInputValues,
                                         MsgModuleIOTabularInputValueUpdated,
                                         MsgModuleIOUpdateInputValues)
 from dharpa.vre.utils.codec import serialize_table
-from stringcase import snakecase, camelcase
+from stringcase import camelcase, snakecase
 
 logger = logging.getLogger(__name__)
 

--- a/backend/jupyter-middleware/dharpa/vre/jupyter/message_handlers/module_io.py
+++ b/backend/jupyter-middleware/dharpa/vre/jupyter/message_handlers/module_io.py
@@ -14,7 +14,7 @@ class ModuleIOHandler(MessageHandler):
         '''
         Return workflow step input values.
         '''
-        values = self.context.get_current_workflow_step_input_values(
+        values = self.context.get_step_input_values(
             msg.id)
 
         self.publisher.publish(MsgModuleIOInputValuesUpdated(
@@ -23,7 +23,7 @@ class ModuleIOHandler(MessageHandler):
         ))
 
     def _handle_UpdateInputValues(self, msg: MsgModuleIOUpdateInputValues):
-        values = self.context.update_current_workflow_step_input_values(
+        values = self.context.update_step_input_values(
             msg.id,
             msg.input_values
         )

--- a/backend/jupyter-middleware/dharpa/vre/jupyter/message_handlers/module_io.py
+++ b/backend/jupyter-middleware/dharpa/vre/jupyter/message_handlers/module_io.py
@@ -1,12 +1,12 @@
 import logging
 
-from dharpa.vre.jupyter.base import MessageEnvelope, MessageHandler, Target
+from dharpa.vre.jupyter.base import MessageEnvelope, MessageHandler
 from dharpa.vre.types.generated import (
     MsgModuleIOGetInputValues,
     MsgModuleIOInputValuesUpdated,
     MsgModuleIOUpdateInputValues,
 )
-from dharpa.vre.utils.dataclasses import from_dict, to_dict
+from dharpa.vre.utils.dataclasses import from_dict
 
 logger = logging.getLogger(__name__)
 
@@ -21,16 +21,10 @@ class ModuleIOHandler(MessageHandler):
         values = self.context.get_current_workflow_step_input_values(
             message.id)
 
-        self.publisher.publish(
-            Target.ModuleIO,
-            MessageEnvelope(
-                action='InputValuesUpdated',
-                content=to_dict(MsgModuleIOInputValuesUpdated(
-                    message.id,
-                    values
-                ))
-            )
-        )
+        self.publisher.publish(MsgModuleIOInputValuesUpdated(
+            message.id,
+            values
+        ))
 
     def _handle_UpdateInputValues(self, msg: MessageEnvelope):
         message = from_dict(MsgModuleIOUpdateInputValues, msg.content)
@@ -39,13 +33,7 @@ class ModuleIOHandler(MessageHandler):
             message.input_values
         )
 
-        self.publisher.publish(
-            Target.ModuleIO,
-            MessageEnvelope(
-                action='InputValuesUpdated',
-                content=to_dict(MsgModuleIOInputValuesUpdated(
-                    message.id,
-                    values
-                ))
-            )
-        )
+        self.publisher.publish(MsgModuleIOInputValuesUpdated(
+            message.id,
+            values
+        ))

--- a/backend/jupyter-middleware/dharpa/vre/jupyter/message_handlers/module_io.py
+++ b/backend/jupyter-middleware/dharpa/vre/jupyter/message_handlers/module_io.py
@@ -1,4 +1,5 @@
 import logging
+from dharpa.vre.context.context import UpdatedIO
 
 from dharpa.vre.jupyter.base import MessageHandler
 from dharpa.vre.types.generated import (MsgModuleIOGetInputValues,
@@ -7,11 +8,42 @@ from dharpa.vre.types.generated import (MsgModuleIOGetInputValues,
                                         MsgModuleIOTabularInputValueUpdated,
                                         MsgModuleIOUpdateInputValues)
 from dharpa.vre.utils.codec import serialize_table
+from stringcase import snakecase, camelcase
 
 logger = logging.getLogger(__name__)
 
 
 class ModuleIOHandler(MessageHandler):
+
+    def initialize(self):
+        self.context.step_input_values_updated.subscribe(
+            self._on_inputs_updated)
+
+    def _on_inputs_updated(self, msg: UpdatedIO):
+        non_tabular_inputs_ids = []
+        for input_id in msg.io_ids:
+            if self.context.is_tabular_input(msg.step_id, input_id):
+                filter = self.context.get_step_tabular_input_filter(
+                    msg.step_id, input_id)
+                value = self.context.get_step_tabular_input_value(
+                    msg.step_id, input_id, filter)
+                self.publisher.publish(MsgModuleIOTabularInputValueUpdated(
+                    id=msg.step_id,
+                    input_id=camelcase(input_id),
+                    filter=filter,
+                    value=serialize_table(value)
+                ))
+            else:
+                non_tabular_inputs_ids.append(input_id)
+
+        if len(non_tabular_inputs_ids) > 0:
+            values = self.context.get_step_input_values(
+                msg.step_id, input_ids=non_tabular_inputs_ids)
+
+            self.publisher.publish(MsgModuleIOInputValuesUpdated(
+                msg.step_id,
+                values
+            ))
 
     def _handle_GetInputValues(self, msg: MsgModuleIOGetInputValues):
         '''
@@ -36,18 +68,22 @@ class ModuleIOHandler(MessageHandler):
             values
         ))
 
+        # TODO: This is here temporary for dev purposes
+        self.context.run_processing(msg.id)
+
     def _handle_GetTabularInputValue(self,
                                      msg: MsgModuleIOGetTabularInputValue):
+        input_id = snakecase(msg.input_id)
         value = self.context.get_step_tabular_input_value(
-            msg.id, msg.input_id, msg.filter)
+            msg.id, input_id, msg.filter)
 
         current_filter = self.context.get_step_tabular_input_filter(
-            msg.id, msg.input_id)
+            msg.id, input_id)
 
         if value is not None:
             self.publisher.publish(MsgModuleIOTabularInputValueUpdated(
                 id=msg.id,
-                input_id=msg.input_id,
+                input_id=input_id,
                 filter=current_filter,
                 value=serialize_table(value)
             ))

--- a/backend/jupyter-middleware/dharpa/vre/jupyter/message_handlers/workflow.py
+++ b/backend/jupyter-middleware/dharpa/vre/jupyter/message_handlers/workflow.py
@@ -1,8 +1,7 @@
 import logging
 
-from dharpa.vre.jupyter.base import MessageEnvelope, MessageHandler, Target
+from dharpa.vre.jupyter.base import MessageEnvelope, MessageHandler
 from dharpa.vre.types import MsgWorkflowUpdated
-from dharpa.vre.utils.dataclasses import to_dict
 
 logger = logging.getLogger(__name__)
 
@@ -13,11 +12,6 @@ class WorkflowMessageHandler(MessageHandler):
         '''
         Return current workflow.
         '''
-        self.publisher.publish(
-            Target.Workflow,
-            MessageEnvelope(
-                action='Updated',
-                content=to_dict(MsgWorkflowUpdated(
-                    self._context.current_workflow
-                ))
-            ))
+        self.publisher.publish(MsgWorkflowUpdated(
+            self._context.current_workflow
+        ))

--- a/backend/jupyter-middleware/dharpa/vre/jupyter/message_handlers/workflow.py
+++ b/backend/jupyter-middleware/dharpa/vre/jupyter/message_handlers/workflow.py
@@ -1,6 +1,6 @@
 import logging
 
-from dharpa.vre.jupyter.base import MessageEnvelope, MessageHandler
+from dharpa.vre.jupyter.base import MessageHandler
 from dharpa.vre.types import MsgWorkflowUpdated
 
 logger = logging.getLogger(__name__)
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 
 class WorkflowMessageHandler(MessageHandler):
 
-    def _handle_GetCurrent(self, msg: MessageEnvelope):
+    def _handle_GetCurrent(self):
         '''
         Return current workflow.
         '''

--- a/backend/jupyter-middleware/dharpa/vre/modules/__init__.py
+++ b/backend/jupyter-middleware/dharpa/vre/modules/__init__.py
@@ -1,0 +1,8 @@
+from . import data_selection  # noqa
+from . import data_upload  # noqa
+from . import two_args_math_fn  # noqa
+from .registry import get_module_processor
+
+__all__ = [
+    'get_module_processor'
+]

--- a/backend/jupyter-middleware/dharpa/vre/modules/data_selection.py
+++ b/backend/jupyter-middleware/dharpa/vre/modules/data_selection.py
@@ -1,0 +1,26 @@
+from dataclasses import dataclass
+from typing import List
+
+import pyarrow as pa
+
+from .registry import dharpa_module
+
+
+@dataclass
+class Inputs:
+    repository_items: 'pa.Table'
+    selected_items_uris: List[str]
+    metadata_fields: List[str]
+
+
+@dataclass
+class Outputs:
+    corpus: 'pa.Table'
+
+
+@dharpa_module('dataSelection')
+def data_selection_process(inputs: Inputs, outputs: Outputs) -> None:
+    repo = inputs.repository_items.to_pandas()
+
+    outputs.corpus = pa.Table.from_pandas(
+        repo[repo['uri'].isin(inputs.selected_items_uris or [])])

--- a/backend/jupyter-middleware/dharpa/vre/modules/data_upload.py
+++ b/backend/jupyter-middleware/dharpa/vre/modules/data_upload.py
@@ -1,0 +1,34 @@
+from dataclasses import dataclass
+from random import random
+from typing import List
+
+import pyarrow as pa
+
+from .registry import dharpa_module
+
+# NOTE: Fake repository
+repository_items = pa.Table.from_pydict({
+    'uri': [f'item-{i}' for i in range(10)],
+    'metadataA': [int(i) for i in range(10)],
+    'metadataB': [random() * i for i in range(10)],
+}, pa.schema({
+    'uri': pa.utf8(),
+    'metadataA': pa.int32(),
+    'metadataB': pa.float64()
+}))
+
+
+@dataclass
+class Inputs:
+    filenames: List[str]
+    metadata_sets: List[str]
+
+
+@dataclass
+class Outputs:
+    repository_items: 'pa.Table'
+
+
+@dharpa_module('dataUpload')
+def data_upload_process(inputs: Inputs, outputs: Outputs) -> None:
+    outputs.repository_items = repository_items

--- a/backend/jupyter-middleware/dharpa/vre/modules/registry.py
+++ b/backend/jupyter-middleware/dharpa/vre/modules/registry.py
@@ -1,0 +1,22 @@
+import logging
+
+from typing import Dict, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+__dharpa_modules_registry: Dict[str, Callable] = {}
+
+
+def dharpa_module(module_name):
+    def decorator(func):
+        if module_name in __dharpa_modules_registry:
+            logger.warn(f'Module "{module_name}" is being registered \
+                more than once with "{func.__name__}"')
+        __dharpa_modules_registry[module_name] = func
+        return func
+    return decorator
+
+
+def get_module_processor(module_name) -> Optional[Callable]:
+    return __dharpa_modules_registry.get(module_name, None)

--- a/backend/jupyter-middleware/dharpa/vre/modules/two_args_math_fn.py
+++ b/backend/jupyter-middleware/dharpa/vre/modules/two_args_math_fn.py
@@ -1,0 +1,32 @@
+from dataclasses import dataclass
+from typing import Optional
+
+
+from .registry import dharpa_module
+
+
+@dataclass
+class Inputs:
+    a: Optional[float] = None
+    b: Optional[float] = None
+    operator: Optional[str] = None
+
+
+@dataclass
+class Outputs:
+    c: float
+
+
+FUNCTIONS = {
+    'add': lambda a, b: a + b,
+    'sub': lambda a, b: a - b,
+    'mul': lambda a, b: a * b,
+    'div': lambda a, b: a / b,
+    'pow': lambda a, b: a ** b,
+}
+
+
+@dharpa_module('twoArgsMathFunction')
+def two_args_math_fn(inputs: Inputs, outputs: Outputs) -> None:
+    fn = FUNCTIONS.get(inputs.operator or 'add')
+    outputs.c = fn(inputs.a or 0, inputs.b or 0)

--- a/backend/jupyter-middleware/dharpa/vre/target.py
+++ b/backend/jupyter-middleware/dharpa/vre/target.py
@@ -1,0 +1,10 @@
+from enum import Enum
+
+
+class Target(Enum):
+    Activity = 'activity'
+    Workflow = 'workflow'
+    ModuleIO = 'module_io'
+    DataRepository = 'data_repository'
+    Parameters = 'parameters'
+    Notes = 'notes'

--- a/backend/jupyter-middleware/dharpa/vre/types/__init__.py
+++ b/backend/jupyter-middleware/dharpa/vre/types/__init__.py
@@ -1,25 +1,32 @@
+from collections import defaultdict
+from typing import Dict, Type
 from .generated import *  # noqa
 from ..target import Target
+
+target_action_mapping: Dict[Target, Dict[str, Type]] = defaultdict(dict)
 
 # Adding "action" and "target" message class metdata
 # to make it easier to deal with publishing of the messages
 
 for k, v in list(globals().items()):
-    if k.startswith('MsgModuleIO'):
-        v._action = k.replace('MsgModuleIO', '')
-        v._target = Target.ModuleIO
-    elif k.startswith('MsgWorkflow'):
-        v._action = k.replace('MsgWorkflow', '')
-        v._target = Target.Workflow
-    elif k.startswith('MsgDataRepository'):
-        v._action = k.replace('MsgDataRepository', '')
-        v._target = Target.DataRepository
-    elif k.startswith('MsgParameters'):
-        v._action = k.replace('MsgParameters', '')
-        v._target = Target.Parameters
-    elif k.startswith('MsgNotes'):
-        v._action = k.replace('MsgNotes', '')
-        v._target = Target.Notes
-    else:
-        v._action = k.replace('Msg', '')
-        v._target = Target.Activity
+    if k.startswith('Msg'):
+        if k.startswith('MsgModuleIO'):
+            v._action = k.replace('MsgModuleIO', '')
+            v._target = Target.ModuleIO
+        elif k.startswith('MsgWorkflow'):
+            v._action = k.replace('MsgWorkflow', '')
+            v._target = Target.Workflow
+        elif k.startswith('MsgDataRepository'):
+            v._action = k.replace('MsgDataRepository', '')
+            v._target = Target.DataRepository
+        elif k.startswith('MsgParameters'):
+            v._action = k.replace('MsgParameters', '')
+            v._target = Target.Parameters
+        elif k.startswith('MsgNotes'):
+            v._action = k.replace('MsgNotes', '')
+            v._target = Target.Notes
+        else:
+            v._action = k.replace('Msg', '')
+            v._target = Target.Activity
+
+        target_action_mapping[v._target][v._action] = v

--- a/backend/jupyter-middleware/dharpa/vre/types/__init__.py
+++ b/backend/jupyter-middleware/dharpa/vre/types/__init__.py
@@ -1,1 +1,25 @@
 from .generated import *  # noqa
+from ..target import Target
+
+# Adding "action" and "target" message class metdata
+# to make it easier to deal with publishing of the messages
+
+for k, v in list(globals().items()):
+    if k.startswith('MsgModuleIO'):
+        v._action = k.replace('MsgModuleIO', '')
+        v._target = Target.ModuleIO
+    elif k.startswith('MsgWorkflow'):
+        v._action = k.replace('MsgWorkflow', '')
+        v._target = Target.Workflow
+    elif k.startswith('MsgDataRepository'):
+        v._action = k.replace('MsgDataRepository', '')
+        v._target = Target.DataRepository
+    elif k.startswith('MsgParameters'):
+        v._action = k.replace('MsgParameters', '')
+        v._target = Target.Parameters
+    elif k.startswith('MsgNotes'):
+        v._action = k.replace('MsgNotes', '')
+        v._target = Target.Notes
+    else:
+        v._action = k.replace('Msg', '')
+        v._target = Target.Activity

--- a/backend/jupyter-middleware/dharpa/vre/types/generated.py
+++ b/backend/jupyter-middleware/dharpa/vre/types/generated.py
@@ -248,7 +248,7 @@ class MsgModuleIOTabularInputValueUpdated:
     """Unique ID of the input"""
     input_id: str
     """The actual value payload. TODO: The type will be set later"""
-    value: Optional[Dict[str, Any]] = None
+    value: Union[Dict[str, Any], None, str]
 
 
 @dataclass

--- a/backend/jupyter-middleware/dharpa/vre/types/generated.py
+++ b/backend/jupyter-middleware/dharpa/vre/types/generated.py
@@ -362,6 +362,8 @@ class WorkflowIOState:
     """Optional default value"""
     default_value: Union[List[Any], bool, float, int, Dict[str, Any], None, str]
     connection: Optional[IOStateConnection] = None
+    """Indicates whether the value is tabular. This field will likely be gone in real backend."""
+    is_tabular: Optional[bool] = None
 
 
 @dataclass

--- a/backend/jupyter-middleware/dharpa/vre/utils/codec.py
+++ b/backend/jupyter-middleware/dharpa/vre/utils/codec.py
@@ -1,0 +1,13 @@
+import base64
+import pyarrow as pa
+
+
+def serialize_table(table: pa.Table) -> str:
+    sink = pa.BufferOutputStream()
+
+    writer = pa.ipc.new_file(sink, table.schema)
+    writer.write(table)
+    writer.close()
+
+    val = sink.getvalue().to_pybytes()
+    return base64.b64encode(val).decode('ascii')

--- a/backend/jupyter-middleware/setup.py
+++ b/backend/jupyter-middleware/setup.py
@@ -30,7 +30,8 @@ setup_args = dict(
         'tinypubsub>=0.1.0',
         'dacite',
         'stringcase>=1.2.0',
-        'pyyaml'
+        'pyyaml',
+        'pyarrow==3.0.0'
     ],
     zip_safe=False,
     include_package_data=True,

--- a/packages/client-core/src/common/types/generated.ts
+++ b/packages/client-core/src/common/types/generated.ts
@@ -311,7 +311,7 @@ export interface MsgModuleIOTabularInputValueUpdated {
   /**
    * The actual value payload. TODO: The type will be set later
    */
-  value?: { [key: string]: unknown }
+  value?: { [key: string]: unknown } | string
 }
 
 /**

--- a/packages/client-core/src/common/types/generated.ts
+++ b/packages/client-core/src/common/types/generated.ts
@@ -511,6 +511,10 @@ export interface WorkflowIOState {
    * Optional default value
    */
   defaultValue?: unknown[] | boolean | number | number | { [key: string]: unknown } | string
+  /**
+   * Indicates whether the value is tabular. This field will likely be gone in real backend.
+   */
+  isTabular?: boolean
 }
 
 /**

--- a/packages/client-core/src/hooks/useStepInputValueBatch.ts
+++ b/packages/client-core/src/hooks/useStepInputValueBatch.ts
@@ -13,7 +13,12 @@ export const useStepInputValueBatch = (stepId: string, inputId: string, filter: 
   useEffect(() => {
     const handler = handlerAdapter(Messages.ModuleIO.codec.TabularInputValueUpdated.decode, content => {
       if (content?.id === stepId && content?.inputId === inputId)
-        setLastValue((content.value as unknown) as Table)
+        if (typeof content.value === 'string') {
+          const table = Table.from([Uint8Array.from(atob(content.value), c => c.charCodeAt(0))])
+          setLastValue(table)
+        } else {
+          setLastValue((content.value as unknown) as Table)
+        }
     })
     context.subscribe(Target.ModuleIO, handler)
 

--- a/packages/jupyter-support/src/readinessProbe.ts
+++ b/packages/jupyter-support/src/readinessProbe.ts
@@ -10,11 +10,11 @@ export enum ReadinessStatus {
   BackEndReady = 2
 }
 
-const BackEndReadyCheckCode = 'Context.get_instance().is_ready'
+const BackEndReadyCheckCode = 'IpythonKernelController.get_instance().is_ready'
 
 const BackEndStartCode = `
-  from dharpa.vre.jupyter.context import Context
-  Context.start()
+  from dharpa.vre.jupyter.controller import IpythonKernelController
+  IpythonKernelController.start()
 `
 
 const isKernelReady = (status: Kernel.Status): boolean => ['idle', 'busy'].includes(status)

--- a/packages/modules/src/dataUpload/index.tsx
+++ b/packages/modules/src/dataUpload/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { ModuleProps, useAddFilesToRepository } from '@dharpa-vre/client-core'
+import { ModuleProps, useAddFilesToRepository, useStepInputValues } from '@dharpa-vre/client-core'
 import { Dropzone } from './Dropzone'
 
 // TODO: This is a special module in the sense that it uses
@@ -23,12 +23,16 @@ const DataUpload = ({ step }: Props): JSX.Element => {
   const [files, setFiles] = React.useState<File[]>([])
   const [isUploading, setIsUploading] = React.useState<boolean>(false)
   const [addFilesToRepository] = useAddFilesToRepository()
+  const [, setInputs] = useStepInputValues(step.id)
 
   const handleFilesAdded = (newFiles: File[]) => setFiles(files.concat(newFiles))
   const handleUploadFiles = () => {
     setIsUploading(true)
     addFilesToRepository(files)
-      .then(() => setFiles([]))
+      .then(() => {
+        setInputs({ filenames: files.map(f => f.name) })
+        setFiles([])
+      })
       .finally(() => setIsUploading(false))
   }
 

--- a/packages/modules/src/twoArgsMathFunction/index.tsx
+++ b/packages/modules/src/twoArgsMathFunction/index.tsx
@@ -30,9 +30,9 @@ const TwoArgsMathFunction = ({ step }: Props): JSX.Element => {
 
   React.useEffect(() => {
     if (inputValues == null) return
-    setA(inputValues.a != null ? String(inputValues.a) : '')
-    setB(inputValues.b != null ? String(inputValues.b) : '')
-    if (inputValues.operator) setOperator(inputValues.operator)
+    if (inputValues.a != null && String(inputValues.a) !== a) setA(String(inputValues.a))
+    if (inputValues.b != null && String(inputValues.b) !== b) setB(String(inputValues.b))
+    if (inputValues.operator != null && inputValues.operator !== operator) setOperator(inputValues.operator)
   }, [inputValues])
 
   React.useEffect(() => {

--- a/schema/json/messages/moduleIO/TabularInputValueUpdated.json
+++ b/schema/json/messages/moduleIO/TabularInputValueUpdated.json
@@ -17,7 +17,10 @@
       "$ref": "https://dharpa.org/schema/types/data/TabularDataFilter.json"
     },
     "value": {
-      "type": "object",
+      "type": [
+        "object",
+        "string"
+      ],
       "description": "The actual value payload. TODO: The type will be set later"
     }
   },

--- a/schema/json/types/workflow/IOState.json
+++ b/schema/json/types/workflow/IOState.json
@@ -18,6 +18,10 @@
         "boolean"
       ],
       "description": "Optional default value"
+    },
+    "isTabular": {
+      "type": "boolean",
+      "description": "Indicates whether the value is tabular. This field will likely be gone in real backend."
     }
   },
   "required": [],


### PR DESCRIPTION
This PR adds a basic `AppContext` interface that exposes API for the most of the backend logic. There is also a mock implementation of this interface that roughly has the same functionality as the browser only mock. The `AppContext` interface will eventually be implemented with `kiara` backend. Several changes to this code will be coming in another PR.