### PR TITLE
Arrow table data grid component

### DIFF
--- a/packages/arrow-data-grid/package.json
+++ b/packages/arrow-data-grid/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@dharpa-vre/arrow-data-grid",
+  "version": "0.1.0",
+  "description": "Data grid view for Apache Arrow Table",
+  "keywords": [
+    "dharpa",
+    "vre",
+    "arrow",
+    "grid",
+    "react"
+  ],
+  "homepage": "https://dharpa.org",
+  "main": "src/index.ts",
+  "license": "AGPL-3.0-only",
+  "author": "roman@kalyakin.com",
+  "scripts": {
+    "watch": "tsc -w",
+    "eslint": "eslint src --ext .ts,.tsx,.js,.jsx --fix",
+    "eslint:check": "eslint src --ext .ts,.tsx,.js,.jsx",
+    "build:lib": "tsc"
+  },
+  "dependencies": {
+    "@material-ui/data-grid": "^4.0.0-alpha.28"
+  },
+  "peerDependencies": {
+    "react": "17",
+    "@dharpa-vre/client-core": "*",
+    "@material-ui/core": "4",
+    "@material-ui/icons": "4"
+  },
+  "devDependencies": {
+    "@types/node": "14",
+    "@types/react": "17",
+    "@typescript-eslint/eslint-plugin": "4",
+    "@typescript-eslint/parser": "4",
+    "eslint": "7",
+    "eslint-config-prettier": "7",
+    "eslint-plugin-prettier": "3",
+    "eslint-plugin-react": "7",
+    "prettier": "2",
+    "typescript": "4"
+  }
+}

--- a/packages/arrow-data-grid/src/DataGrid.styles.ts
+++ b/packages/arrow-data-grid/src/DataGrid.styles.ts
@@ -34,16 +34,16 @@ export const useStyles = makeStyles((theme: Theme) => ({
       marginTop: theme.spacing(7)
     },
     '& .MuiDataGrid-viewport': {
-      maxHeight: 'fit-content! important'
+      maxHeight: 'fit-content !important'
     },
     '& .MuiDataGrid-renderingZone': {
-      maxHeight: 'fit-content! important'
+      maxHeight: 'fit-content !important'
     },
     '& .MuiDataGrid-row': {
-      maxHeight: 'fit-content! important'
+      maxHeight: 'fit-content !important'
     },
     '& .MuiDataGrid-cell': {
-      maxHeight: 'fit-content! important',
+      maxHeight: 'fit-content !important',
       lineHeight: 'inherit !important'
     },
     '& .MuiDataGrid-cell:focus': {

--- a/packages/arrow-data-grid/src/DataGrid.styles.ts
+++ b/packages/arrow-data-grid/src/DataGrid.styles.ts
@@ -1,0 +1,53 @@
+import { makeStyles, Theme, useTheme } from '@material-ui/core/styles'
+
+const HeaderHeightUnits = 7
+
+const CondensetRowHeightUnits = 3
+const DefaultRowHeightUnits = 6.5
+
+interface Heights {
+  header: number
+  row: number
+}
+
+interface UseHeightsProps {
+  rowCondensed: boolean
+}
+
+export const useHeights = ({ rowCondensed }: UseHeightsProps): Heights => {
+  const theme = useTheme()
+
+  return {
+    header: theme.spacing(HeaderHeightUnits),
+    row: theme.spacing(rowCondensed ? CondensetRowHeightUnits : DefaultRowHeightUnits)
+  }
+}
+
+export const useStyles = makeStyles((theme: Theme) => ({
+  root: {
+    '& .MuiDataGrid-windowContainer': {
+      height: 'auto !important'
+    },
+    '& .MuiDataGrid-window': {
+      position: 'inherit',
+      top: '0 !important',
+      marginTop: theme.spacing(7)
+    },
+    '& .MuiDataGrid-viewport': {
+      maxHeight: 'fit-content! important'
+    },
+    '& .MuiDataGrid-renderingZone': {
+      maxHeight: 'fit-content! important'
+    },
+    '& .MuiDataGrid-row': {
+      maxHeight: 'fit-content! important'
+    },
+    '& .MuiDataGrid-cell': {
+      maxHeight: 'fit-content! important',
+      lineHeight: 'inherit !important'
+    },
+    '& .MuiDataGrid-cell:focus': {
+      outline: 'none !important'
+    }
+  }
+}))

--- a/packages/arrow-data-grid/src/DataGrid.tsx
+++ b/packages/arrow-data-grid/src/DataGrid.tsx
@@ -1,0 +1,149 @@
+import React from 'react'
+import { Table, Field } from 'apache-arrow'
+import {
+  DataGrid as MuiDataGrid,
+  GridColumns,
+  GridRowsProp,
+  GridColDef,
+  GridRowData
+} from '@material-ui/data-grid'
+import { TableStats, TabularDataFilter } from '@dharpa-vre/client-core'
+import { getCellRenderer } from './cellRenderers'
+import { getHeaderRenderer } from './headerRenderer'
+import { useStyles, useHeights } from './DataGrid.styles'
+
+const DefaultPageSize = 10
+
+export interface DataGridProps {
+  data: Table
+  stats?: TableStats
+  filter?: TabularDataFilter
+  onFiltering?: (filter: TabularDataFilter) => void
+  condensed?: boolean
+}
+
+export const DataGrid = ({
+  data,
+  stats,
+  onFiltering,
+  filter,
+  condensed = false
+}: DataGridProps): JSX.Element => {
+  const [currentPage, setCurrentPage] = React.useState(0)
+  const [pageSize, setPageSize] = React.useState(filter?.pageSize ?? DefaultPageSize)
+  const [isLoading, setIsLoading] = React.useState(false)
+  const classes = useStyles()
+  const heights = useHeights({ rowCondensed: condensed })
+
+  /**
+   * When the grid is in "server" mode it means that the "data" property
+   * includes only a part (page) of the whole data. In this mode when pagination,
+   * filtering or sorting is requested by the user interacting with the grid,
+   * the "onFiltering" property is called to instruct the backend to get more data.
+   */
+  const gridIsInServerMode = data?.length < stats?.rowsCount && stats?.rowsCount != null
+
+  React.useEffect(() => {
+    if (!gridIsInServerMode) return
+
+    if (filter == null) {
+      console.warn(
+        'The grid "data" property contains a subset of the whole data, but the "filter" property is not provided.'
+      )
+    }
+
+    const pageOffset = currentPage * pageSize
+    const newFilter: TabularDataFilter = { ...filter, offset: pageOffset }
+
+    if (onFiltering == null) {
+      console.warn(
+        'The grid "data" property contains a subset of the whole data, but the "onFiltering" property is not provided.'
+      )
+    }
+
+    onFiltering?.(newFilter)
+  }, [currentPage])
+
+  React.useEffect(() => {
+    if (gridIsInServerMode) {
+      const pageOffset = currentPage * pageSize
+      setIsLoading(pageOffset >= stats?.rowsCount || (data?.length ?? 0) === 0)
+    } else {
+      setIsLoading(data == null)
+    }
+  }, [data, currentPage, pageSize])
+
+  React.useEffect(() => {
+    if (filter?.offset == null) return
+    const newCurrentPage = Math.floor(filter?.offset / pageSize)
+    setCurrentPage(newCurrentPage)
+  }, [filter?.offset])
+
+  React.useEffect(() => {
+    if (filter?.pageSize == null) return
+    setPageSize(filter?.pageSize)
+  }, [filter?.pageSize])
+
+  if (data == null) return <></>
+
+  return (
+    <MuiDataGrid
+      className={classes.root}
+      columns={getColumns(data)}
+      rows={getRows(data, gridIsInServerMode ? 0 : currentPage, pageSize)}
+      pageSize={pageSize}
+      page={currentPage}
+      onPageChange={p => setCurrentPage(p.page)}
+      paginationMode="server"
+      autoHeight
+      rowCount={gridIsInServerMode ? stats?.rowsCount : data?.length}
+      sortingMode="server"
+      loading={isLoading}
+      disableColumnSelector
+      disableSelectionOnClick
+      rowHeight={heights.row}
+      headerHeight={heights.header}
+    ></MuiDataGrid>
+  )
+}
+
+function getColumns(data: Table): GridColumns {
+  return data?.schema?.fields?.map(toColDef) ?? []
+}
+
+function getRows(data: Table, page: number, pageSize: number): GridRowsProp {
+  const offset = page * pageSize
+  const rows: GridRowsProp = []
+  const slice = data.slice(offset, offset + pageSize)
+  const columns = data.schema.fields.map(f => f.name)
+
+  let idx = offset
+  for (const row of slice) {
+    rows.push(toRow(row, columns, idx++))
+  }
+
+  return rows
+}
+
+function toColDef(field: Field): GridColDef {
+  return {
+    field: field.name,
+    headerName: field.metadata.get('title') ?? field.name,
+    description: field.metadata.get('description'),
+    flex: 1,
+    sortable: false, // we do not support sorting yet
+    filterable: false, // we do not support filtering yet
+    editable: false, // we do not support editing
+    renderCell: getCellRenderer(field.type),
+    renderHeader: getHeaderRenderer(field.type)
+  }
+}
+function toRow(row: ReturnType<Table['get']>, columns: string[], index: number): GridRowData {
+  const data = columns.reduce(
+    (acc, column) => ({ ...acc, [column]: row.get(column) }),
+    {} as { [key: string]: unknown }
+  )
+  // Row must have and 'id' field: https://material-ui.com/components/data-grid/rows/
+  if (!columns.includes('id')) data['id'] = index
+  return data
+}

--- a/packages/arrow-data-grid/src/cellRenderers/DefaultRenderer.tsx
+++ b/packages/arrow-data-grid/src/cellRenderers/DefaultRenderer.tsx
@@ -1,0 +1,7 @@
+import React from 'react'
+import { Box } from '@material-ui/core'
+import { GridCellParams } from '@material-ui/data-grid'
+
+export const DefaultRenderer = (params: GridCellParams): JSX.Element => {
+  return <Box>{String(params.value)}</Box>
+}

--- a/packages/arrow-data-grid/src/cellRenderers/ListRenderer.tsx
+++ b/packages/arrow-data-grid/src/cellRenderers/ListRenderer.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { Grid } from '@material-ui/core'
+import { GridCellParams } from '@material-ui/data-grid'
+import { Vector } from 'apache-arrow'
+import { DefaultRenderer } from './DefaultRenderer'
+
+export interface ListCellRendererParams extends GridCellParams {
+  itemRenderer?: (params: GridCellParams) => React.ReactElement
+}
+
+export const ListCellRenderer = ({
+  value,
+  itemRenderer = DefaultRenderer,
+  ...rest
+}: ListCellRendererParams): JSX.Element => {
+  const items: Vector = (value as unknown) as Vector
+  const Renderer = itemRenderer ?? DefaultRenderer
+  return (
+    <Grid container direction="column" spacing={0}>
+      {[...items.toArray()].map((item, idx) => (
+        <Grid item key={idx}>
+          <Renderer {...rest} value={item} />
+        </Grid>
+      ))}
+    </Grid>
+  )
+}

--- a/packages/arrow-data-grid/src/cellRenderers/StructRenderer.tsx
+++ b/packages/arrow-data-grid/src/cellRenderers/StructRenderer.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { Typography, Box } from '@material-ui/core'
+import { GridCellParams } from '@material-ui/data-grid'
+import grey from '@material-ui/core/colors/grey'
+
+export const StructRenderer = ({ value }: GridCellParams): JSX.Element => {
+  const formattedValue = JSON.stringify(JSON.parse(String(value)), null, 2)
+  return (
+    <Box mt={1} mb={1} bgcolor={grey[100]} p={1} color={grey[600]} fontWeight="bold">
+      <Typography variant="body2" component="code" gutterBottom style={{ whiteSpace: 'pre' }}>
+        {formattedValue}
+      </Typography>
+    </Box>
+  )
+}

--- a/packages/arrow-data-grid/src/cellRenderers/index.ts
+++ b/packages/arrow-data-grid/src/cellRenderers/index.ts
@@ -1,0 +1,16 @@
+import { DataType, List, Struct } from 'apache-arrow'
+import { GridCellParams } from '@material-ui/data-grid'
+
+import { DefaultRenderer } from './DefaultRenderer'
+import { ListCellRenderer } from './ListRenderer'
+import { StructRenderer } from './StructRenderer'
+
+export function getCellRenderer(type: DataType): (params: GridCellParams) => React.ReactElement {
+  if (type instanceof List) {
+    return (params: GridCellParams) =>
+      ListCellRenderer({ ...params, itemRenderer: getCellRenderer(type.valueType) })
+  } else if (type instanceof Struct) {
+    return StructRenderer
+  }
+  return DefaultRenderer
+}

--- a/packages/arrow-data-grid/src/headerRenderer.tsx
+++ b/packages/arrow-data-grid/src/headerRenderer.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { Grid, SvgIcon } from '@material-ui/core'
+import { GridColumnHeaderParams } from '@material-ui/data-grid'
+import { DataType, Type } from 'apache-arrow'
+import TextIcon from '@material-ui/icons/TextFields'
+import ListIcon from '@material-ui/icons/List'
+import StructIcon from '@material-ui/icons/Description'
+import DateIcon from '@material-ui/icons/DateRange'
+import TimeIcon from '@material-ui/icons/AccessTime'
+
+type Renderer = (params: GridColumnHeaderParams) => React.ReactElement
+type IconType = typeof SvgIcon
+
+export function getHeaderRenderer(type: DataType): Renderer {
+  const icon = getIcon(type)
+  return (params: GridColumnHeaderParams) => headerRenderer({ ...params, icon })
+}
+
+type HeaderRendererProps = GridColumnHeaderParams & { icon: IconType }
+const headerRenderer = (props: HeaderRendererProps): JSX.Element => {
+  if (props.icon == null) return undefined
+  const Icon = props.icon
+  return (
+    <Grid container alignItems="center" spacing={1}>
+      <Grid item>
+        <Icon style={{ verticalAlign: 'middle' }} fontSize="small" />
+      </Grid>
+      <Grid item>{props.colDef.headerName}</Grid>
+    </Grid>
+  )
+}
+
+const getIcon = (type: DataType): typeof SvgIcon => {
+  switch (type.typeId) {
+    case Type.Utf8:
+      return TextIcon
+    case Type.List:
+    case Type.FixedSizeList:
+      return ListIcon
+    case Type.Struct:
+    case Type.Map:
+      return StructIcon
+    case Type.Time:
+      return TimeIcon
+    case Type.Date:
+      return DateIcon
+    default:
+      return undefined
+  }
+}

--- a/packages/arrow-data-grid/src/index.ts
+++ b/packages/arrow-data-grid/src/index.ts
@@ -1,0 +1,1 @@
+export * from './DataGrid'

--- a/packages/arrow-data-grid/tsconfig.json
+++ b/packages/arrow-data-grid/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/packages/modules/src/dataSelection/index.tsx
+++ b/packages/modules/src/dataSelection/index.tsx
@@ -11,6 +11,7 @@ import {
 } from '@dharpa-vre/client-core'
 import { Table } from 'apache-arrow'
 import { TableView } from '../components/TableView'
+import { DataGrid } from '@dharpa-vre/arrow-data-grid'
 
 interface InputValues {
   repositoryItems?: Table<DataRepositoryItemStructure>
@@ -42,7 +43,7 @@ const DataSelection = ({ step }: Props): JSX.Element => {
   }
 
   const updateRepositoryItemsFilter = (filter: DataRepositoryItemsFilter) =>
-    setRepositoryItemsFilter({ ...filter, pageSize: 5, types: ['table'] })
+    setRepositoryItemsFilter({ pageSize: 5, ...filter, types: ['table'] })
 
   return (
     <div key={step.stepId}>
@@ -82,6 +83,13 @@ const DataSelection = ({ step }: Props): JSX.Element => {
             })}
         </ul>
       )}
+      <DataGrid
+        data={repositoryItemsBatch?.select('id', 'alias', 'columnNames')}
+        stats={repositoryStats}
+        filter={repositoryItemsFilter}
+        onFiltering={updateRepositoryItemsFilter}
+        condensed
+      />
     </div>
   )
 }

--- a/packages/modules/src/networkAnalysisDataMapping/index.tsx
+++ b/packages/modules/src/networkAnalysisDataMapping/index.tsx
@@ -9,6 +9,7 @@ import {
 import { Table, Utf8Vector, Int32Vector } from 'apache-arrow'
 import { MappingTableStructure, toObject, fromObject } from './mappingTable'
 import { EdgesStructure, NodesStructure } from '../networkAnalysisDataVis/structure'
+import { DataGrid } from '@dharpa-vre/arrow-data-grid'
 
 type CorpusStructure = DataRepositoryItemStructure
 
@@ -127,6 +128,7 @@ const NetworkAnalysisDataMapping = ({ step }: Props): JSX.Element => {
           })}
         </ul>
       </div>
+      <DataGrid data={edgesMappingTable} />
     </div>
   )
 }

--- a/packages/modules/src/networkAnalysisDataVis/index.tsx
+++ b/packages/modules/src/networkAnalysisDataVis/index.tsx
@@ -22,6 +22,7 @@ import {
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore'
 import { useElement, NetworkForce } from '@dharpa-vre/datavis-components'
 import { useBbox } from '../hooks/useBbox'
+import { DataGrid } from '@dharpa-vre/arrow-data-grid'
 
 useElement('network-force')
 
@@ -209,6 +210,11 @@ const NetworkAnalysisDataVis = ({ step }: Props): JSX.Element => {
             height={graphHeight}
             ref={graphRef}
           />
+        </Grid>
+      </Grid>
+      <Grid container>
+        <Grid item style={{ flexGrow: 1 }}>
+          <DataGrid data={nodes} condensed />
         </Grid>
       </Grid>
     </Grid>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1590,6 +1590,15 @@
     react-is "^16.8.0 || ^17.0.0"
     react-transition-group "^4.4.0"
 
+"@material-ui/data-grid@^4.0.0-alpha.28":
+  version "4.0.0-alpha.28"
+  resolved "https://registry.yarnpkg.com/@material-ui/data-grid/-/data-grid-4.0.0-alpha.28.tgz#a82f0e382c8abffa7e7d50d31a4706f8c30215e9"
+  integrity sha512-a6xZj0pMIX2uGsyMMZP/kZISo7MKS43+hHApoHeije82yMAPKhTXV7/SCuAFoF9qye14XeSclwmwOkN2AJRAPg==
+  dependencies:
+    "@material-ui/utils" "^5.0.0-alpha.14"
+    prop-types "^15.7.2"
+    reselect "^4.0.0"
+
 "@material-ui/icons@^4.11.2":
   version "4.11.2"
   resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-4.11.2.tgz#b3a7353266519cd743b6461ae9fdfcb1b25eb4c5"
@@ -1660,6 +1669,17 @@
     "@babel/runtime" "^7.4.4"
     prop-types "^15.7.2"
     react-is "^16.8.0 || ^17.0.0"
+
+"@material-ui/utils@^5.0.0-alpha.14":
+  version "5.0.0-alpha.33"
+  resolved "https://registry.yarnpkg.com/@material-ui/utils/-/utils-5.0.0-alpha.33.tgz#ed2961ce9e700cb3af1a7e663af67d33e8455fdb"
+  integrity sha512-jzXUtTntCC7fumvXvT+scHj6t/A+qUKJ3XM/C1ZtPmPg4dA5+XmhD8uU9wZU3IuaDb66LJdZnfnhRD72052k+Q==
+  dependencies:
+    "@babel/runtime" "^7.4.4"
+    "@types/prop-types" "^15.7.3"
+    "@types/react-is" "^16.7.1 || ^17.0.0"
+    prop-types "^15.7.2"
+    react-is "^17.0.0"
 
 "@nodelib/fs.scandir@2.1.4":
   version "2.1.4"
@@ -2060,7 +2080,7 @@
     "@types/node" "*"
     xmlbuilder ">=11.0.1"
 
-"@types/prop-types@*":
+"@types/prop-types@*", "@types/prop-types@^15.7.3":
   version "15.7.3"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
@@ -2076,6 +2096,13 @@
   version "17.0.3"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.3.tgz#7fdf37b8af9d6d40127137865bb3fff8871d7ee1"
   integrity sha512-4NnJbCeWE+8YBzupn/YrJxZ8VnjcJq5iR1laqQ1vkpQgBiA7bwk0Rp24fxsdNinzJY2U+HHS4dJJDPdoMjdJ7w==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react-is@^16.7.1 || ^17.0.0":
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react-is/-/react-is-17.0.0.tgz#6b60190ae60591ae0c83d6f3854e61e08f5a7976"
+  integrity sha512-A0DQ1YWZ0RG2+PV7neAotNCIh8gZ3z7tQnDJyS2xRPDNtAtSPcJ9YyfMP8be36Ha0kQRzbZCrrTMznA4blqO5g==
   dependencies:
     "@types/react" "*"
 
@@ -7622,7 +7649,7 @@ react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
-"react-is@^16.8.0 || ^17.0.0":
+"react-is@^16.8.0 || ^17.0.0", react-is@^17.0.0:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
@@ -8066,6 +8093,11 @@ requires-port@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
+
+reselect@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/reselect/-/reselect-4.0.0.tgz#f2529830e5d3d0e021408b246a206ef4ea4437f7"
+  integrity sha512-qUgANli03jjAyGlnbYVAV5vvnOmJnODyABz51RdBN7M4WaVu8mecZWgyQNkG8Yqe3KRGRt0l4K4B3XVEULC4CA==
 
 resize-observer-polyfill@^1.5.1:
   version "1.5.1"


### PR DESCRIPTION
Generic component for rendering arrow tables.

Based on [Material UI Data Grid](https://material-ui.com/components/data-grid/#mit-version). Renders any data in [Arrow Table](https://arrow.apache.org/docs/js/classes/arrow_dom.table.html) format. Server side pagination with [TableStats](https://github.com/DHARPA-Project/codename-vre/blob/master/packages/client-core/src/common/types/generated.ts#L514) and [TabularDataFilter](https://github.com/DHARPA-Project/codename-vre/blob/master/packages/client-core/src/common/types/generated.ts#L180)

Filtering and sorting is supported by Data Grid, but not yet implemented in the VRE. It will be enabled in another PR. 